### PR TITLE
feat: add snapcraft config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: grin
+version: v2.1.1
+summary: Minimal implementation of the Mimblewimble protocol
+description: |
+  https://grin.mw/
+
+epoch: 2
+confinement: strict
+grade: stable
+base: core18
+parts:
+  grin:
+    plugin: rust
+    source: https://github.com/mimblewimble/grin.git
+    source-tag: v2.1.1
+    build-packages:
+      - clang
+      - libncurses5-dev
+      - libncursesw5-dev
+  wallet:
+    plugin: rust
+    source: https://github.com/mimblewimble/grin-wallet.git
+    source-tag: v2.1.0
+    build-packages:
+      - clang
+
+apps:
+  grin:
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+    command: bin/grin
+    plugs: [network, network-bind]
+  wallet:
+    command: bin/grin-wallet
+    plugs: [network, network-bind]


### PR DESCRIPTION
Config for first deployment of Grin through Snap. It's had about 50 installs now, I haven't heard any issues. Tried it on a fresh install of Ubuntu yesterday and it worked well.