### PR TITLE
Change snap craft confinement policy

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,11 @@
 name: grin
-version: v5.0.2
+version: v5.0.3
 summary: Minimal implementation of the Mimblewimble protocol
 description: |
   https://grin.mw/
 
 epoch: 3*
-confinement: strict
+confinement: classic
 grade: stable
 base: core18
 parts:


### PR DESCRIPTION
Change to classic to allow snap craft to use Tor and release v5.0.3